### PR TITLE
Fix global array indexing in RISC-V codegen

### DIFF
--- a/src/backend/riscv_codegen.cpp
+++ b/src/backend/riscv_codegen.cpp
@@ -442,7 +442,6 @@ void CodeGen::Visit(const koopa_raw_get_elem_ptr_t &get_elem_ptr) {
         << "\n";
     auto idx_addr = addr_manager.getAddr(get_elem_ptr.index);
     cmd_li(get_elem_ptr.index, idx_addr);
-    oss << "  lw " << res_addr << ", 0(" << res_addr << ")\n";
     oss << "  li t6, " << 4 << "\n";
     oss << "  mul t6, " << idx_addr << ", t6\n";
     oss << "  add " << res_addr << ", " << res_addr << ", t6\n";

--- a/tests/basic/array_sum.sy
+++ b/tests/basic/array_sum.sy
@@ -1,0 +1,11 @@
+const int garr[10] = {6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+
+int main() {
+  const int arr[10] = {1, 2, 3, 4, 5};
+  int i = 0, sum = 0;
+  while (i < 10) {
+    sum = sum + arr[i] + garr[i];
+    i = i + 1;
+  }
+  return sum;
+}


### PR DESCRIPTION
## Summary
- correct `get_elem_ptr` generation for global arrays
- add regression test exercising global and local constant arrays

## Testing
- `cmake -B build`
- `cmake --build build`
- `for f in tests/basic/*.sy; do ./build/compiler -koopa $f -o /tmp/out.koopa || exit 1; done`
- `for f in tests/basic/*.sy; do ./build/compiler -riscv $f -o /tmp/out.s || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_6863f9a6e1d08323b79fd98af8ee1292