### PR TITLE
Add preliminary multi-dimensional array parsing

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -136,19 +136,36 @@ public:
   void print(std::ostream &os) override;
 };
 
+class InitValAST : public BaseAST {
+public:
+  enum Kind { EXP, LIST };
+  Kind kind;
+  std::unique_ptr<ExpAST> exp;                                     // EXP
+  std::vector<std::unique_ptr<InitValAST>> *list = nullptr; // LIST
+  void print(std::ostream &os) override;
+};
+
+class ConstInitValAST : public BaseAST {
+public:
+  enum Kind { EXP, LIST };
+  Kind kind;
+  std::unique_ptr<ExpAST> exp;
+  std::vector<std::unique_ptr<ConstInitValAST>> *list = nullptr;
+  void print(std::ostream &os) override;
+};
+
 class VarDefAST : public DefAST {
 public:
-  std::unique_ptr<ExpAST> init_val;
-  std::unique_ptr<ExpAST> array_size; // 数组大小（仅在数组声明时使用）
-  std::vector<std::unique_ptr<ExpAST>> *init_array_val; // 数组初始化值列表
+  std::unique_ptr<InitValAST> init_val;
+  std::vector<std::unique_ptr<ExpAST>> *array_dims = nullptr; // 多维数组尺寸
   void print(std::ostream &os) override;
 };
 
 class ConstDefAST : public DefAST {
 public:
-  int const_init_val;
-  int array_size; // 数组大小（仅在数组声明时使用）
-  std::vector<int> *const_init_array_val;
+  int const_init_val = 0;
+  std::vector<int> array_dims; // 多维数组尺寸
+  std::unique_ptr<ConstInitValAST> const_init_val_ast;
   void print(std::ostream &os) override;
 };
 
@@ -174,7 +191,7 @@ public:
   enum Kind { IDENT, ARRAY_ACCESS };
   Kind kind;
   std::string ident;
-  std::unique_ptr<ExpAST> array_index; // 仅在 ARRAY_ACCESS 时使用
+  std::vector<std::unique_ptr<ExpAST>> *array_index_list = nullptr; // 多维数组下标
   void print(std::ostream &os) override;
 };
 

--- a/include/symbol_table.h
+++ b/include/symbol_table.h
@@ -13,6 +13,7 @@ public:
 
   std::map<std::string, int> val_map;
   std::map<std::string, std::vector<int>> const_array_val_map;
+  std::map<std::string, std::vector<int>> array_dims_map;
   std::map<std::string, std::string> type_map;
   std::map<std::string, DefType> def_type_map;
 
@@ -36,6 +37,8 @@ public:
   std::string get_lval_ident(const std::string &ident);
   SymbolTable::DefType get_def_type(const std::string &ident);
   std::vector<int> get_const_array_val(const std::string &ident);
+  std::vector<int> get_array_dims(const std::string &ident);
+  void set_array_dims(const std::string &ident, const std::vector<int> &dims);
   std::vector<FuncFParamAST> get_func_fparams(const std::string &ident);
 
   void alloc_ident(const std::string &ident);

--- a/src/frontend/symbol_table.cpp
+++ b/src/frontend/symbol_table.cpp
@@ -99,6 +99,17 @@ std::vector<int> SymbolTableManger::get_const_array_val(const std::string &ident
   return table->const_array_val_map[ident];
 }
 
+std::vector<int> SymbolTableManger::get_array_dims(const std::string &ident) {
+  auto table = find_table(ident);
+  assert(table);
+  return table->array_dims_map[ident];
+}
+
+void SymbolTableManger::set_array_dims(const std::string &ident,
+                                       const std::vector<int> &dims) {
+  get_back_table().array_dims_map[ident] = dims;
+}
+
 std::vector<FuncFParamAST>
 SymbolTableManger::get_func_fparams(const std::string &ident) {
   auto table = find_table(ident);


### PR DESCRIPTION
## Summary
- extend AST with `InitValAST` and `ConstInitValAST`
- store array dimensions in symbol table
- update parser grammar to parse multi-dimensional arrays
- adjust AST printing to handle existing single-dim cases and leave TODOs

## Testing
- `cmake -B build`
- `cmake --build build`
- `build/compiler -koopa tests/basic/array_sum.sy -o /tmp/array_sum.koopa`

------
https://chatgpt.com/codex/tasks/task_e_6865f6342688832398d9366bc55299b0