### PR TITLE
Add array parameter parsing

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -122,11 +122,14 @@ public:
 
 class FuncFParamAST : public BaseAST {
 public:
-  FuncFParamAST() : b_type(""), ident("") {}
-  FuncFParamAST(std::string b_type, std::string ident)
-      : b_type(b_type), ident(ident) {}
+  FuncFParamAST()
+      : b_type(""), ident(""), array_dims(nullptr) {}
+  FuncFParamAST(std::string b_type, std::string ident,
+                std::vector<std::unique_ptr<ExpAST>> *array_dims = nullptr)
+      : b_type(b_type), ident(ident), array_dims(array_dims) {}
   std::string b_type;
   std::string ident;
+  std::vector<std::unique_ptr<ExpAST>> *array_dims;
   void print(std::ostream &os) override;
 };
 

--- a/src/frontend/ast.cpp
+++ b/src/frontend/ast.cpp
@@ -86,7 +86,9 @@ void FuncDefAST::print(std::ostream &os) {
     int n = func_fparams.size();
     for (int i = 0; i < n; i++) {
       os << "@" << func_fparams[i].ident << ": ";
-      if (func_fparams[i].b_type == "int") {
+      if (func_fparams[i].array_dims != nullptr) {
+        os << "*i32"; // TODO: support multi-dimensional arrays
+      } else if (func_fparams[i].b_type == "int") {
         os << "i32";
       } else {
         assert(false);
@@ -114,13 +116,20 @@ void FuncDefAST::print(std::ostream &os) {
       SymbolTableManger::getInstance()
           .get_back_table()
           .def_type_map[func_fparams[i].ident] =
-          SymbolTable::DefType::VAR_IDENT;
+          func_fparams[i].array_dims != nullptr
+              ? SymbolTable::DefType::VAR_ARRAY
+              : SymbolTable::DefType::VAR_IDENT;
       SymbolTableManger::getInstance()
           .get_back_table()
           .lval_ident_map[func_fparams[i].ident] =
           this->ident + "_" + func_fparams[i].ident;
-      os << "  @" << this->ident << "_" << func_fparams[i].ident
-         << " = alloc i32\n";
+      if (func_fparams[i].array_dims != nullptr) {
+        os << "  @" << this->ident << "_" << func_fparams[i].ident
+           << " = alloc *i32\n"; // TODO: real array param handling
+      } else {
+        os << "  @" << this->ident << "_" << func_fparams[i].ident
+           << " = alloc i32\n";
+      }
       os << "  store @" << func_fparams[i].ident << ", @" << this->ident << "_"
          << func_fparams[i].ident << "\n";
     }

--- a/src/frontend/sysy.y
+++ b/src/frontend/sysy.y
@@ -75,7 +75,7 @@ using namespace std;
 %type <ast_vec_val> BlockItemList CompUnitList
 %type <def_ast_val> ConstDef VarDef 
 %type <def_ast_vec_val> ConstDefList VarDefList 
-%type <exp_ast_vec_val> FuncRParamList IndexList DimList
+%type <exp_ast_vec_val> FuncRParamList IndexList DimList FuncFParamDimList
 %type <init_val_ast_vec_val> InitValList InitValListOpt
 %type <func_fparam_ast_vec_val> FuncFParamList
 %type <const_init_val_ast_val> ConstInitVal
@@ -133,14 +133,32 @@ FuncFParamList
   }
   ;
 
-// FuncFParam ::= BType IDENT;
+// FuncFParam ::= BType IDENT
+//              | BType IDENT "[" "]" { "[" ConstExp "]" }
 FuncFParam
   : Type IDENT {
     auto ast = new FuncFParamAST();
     ast->b_type = *unique_ptr<string>($1);
     ast->ident = *unique_ptr<string>($2);
+    ast->array_dims = nullptr;
     $$ = ast;
   }
+  | Type IDENT '[' ']' FuncFParamDimList {
+    auto ast = new FuncFParamAST();
+    ast->b_type = *unique_ptr<string>($1);
+    ast->ident = *unique_ptr<string>($2);
+    ast->array_dims = $5;
+    $$ = ast;
+  }
+  ;
+
+FuncFParamDimList
+  : /* empty */ { auto vec = new vector<std::unique_ptr<ExpAST>>(); $$ = vec; }
+  | FuncFParamDimList '[' ConstExp ']' {
+      auto vec = $1;
+      vec->push_back(std::unique_ptr<ExpAST>($3));
+      $$ = vec;
+    }
   ;
 
 // FuncDef ::= FuncType IDENT '(' [FuncFParamList] ')' Block;


### PR DESCRIPTION
## Summary
- extend `FuncFParamAST` to keep optional array dimensions
- allow `FuncFParam` grammar rule to parse forms like `BType ident[] [ConstExp]...`
- output pointer type for array parameters in generated IR

## Testing
- `cmake -B build`
- `cmake --build build`
- `build/compiler -koopa tests/basic/expr_simple.sy -o expr_simple.koopa`
- `build/compiler -koopa tests/basic/array_sum.sy -o array_sum.koopa`

------
https://chatgpt.com/codex/tasks/task_e_68669a6c2510832385cbe0cbb8949cad